### PR TITLE
CircuitBreaker Optimizations

### DIFF
--- a/assets/eip-7265/foundry.toml
+++ b/assets/eip-7265/foundry.toml
@@ -2,6 +2,6 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-solc = "0.8.20"
+solc = "0.8.22"
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/assets/eip-7265/src/core/CircuitBreaker.sol
+++ b/assets/eip-7265/src/core/CircuitBreaker.sol
@@ -228,7 +228,7 @@ contract CircuitBreaker is IERC7265CircuitBreaker, Ownable {
         uint256 _tickTimestamp
     ) external view returns (uint256 nextTimestamp, int256 amount) {
         LiqChangeNode storage node = limiters[identifier].listNodes[
-            _tickTimestamp
+            uint32(_tickTimestamp)  
         ];
         nextTimestamp = node.nextTimestamp;
         amount = node.amount;

--- a/assets/eip-7265/src/interfaces/IERC7265CircuitBreaker.sol
+++ b/assets/eip-7265/src/interfaces/IERC7265CircuitBreaker.sol
@@ -164,12 +164,6 @@ interface IERC7265CircuitBreaker {
     /// MUST revert if the circuit breaker is not currently rate limited.
     function overrideRateLimit(bytes32 identifier) external;
 
-    /// @notice Override an expired rate limit
-    /// @dev This method MAY be called by anyone once the cooldown period is complete. 
-    /// MUST revert if the cooldown period is not complete.
-    /// MUST revert if the circuit breaker is not currently rate limited.
-    function overrideExpiredRateLimit() external;
-
     /// @notice Check if the circuit breaker is currently in grace period
     /// @return isInGracePeriod MUST return TRUE if the circuit breaker is currently in grace period, FALSE otherwise
     function isInGracePeriod() external view returns (bool);

--- a/assets/eip-7265/src/static/Structs.sol
+++ b/assets/eip-7265/src/static/Structs.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.19;
 
 struct LiqChangeNode {
-    uint256 nextTimestamp;
+    uint32 nextTimestamp;
     int256 amount;
 }
 
@@ -13,9 +13,9 @@ struct Limiter {
     uint256 limitBeginThreshold;
     int256 liqTotal;
     int256 liqInPeriod;
-    uint256 listHead;
-    uint256 listTail;
-    mapping(uint256 tick => LiqChangeNode node) listNodes;
+    uint32 listHead;
+    uint32 listTail;
+    mapping(uint32 tick => LiqChangeNode node) listNodes;
     ISettlementModule settlementModule;
     bool overriden;
 }

--- a/assets/eip-7265/src/utils/LimiterLib.sol
+++ b/assets/eip-7265/src/utils/LimiterLib.sol
@@ -119,8 +119,10 @@ library LimiterLib {
         ) {
             LiqChangeNode storage node = limiter.listNodes[currentHead];
             totalChange += node.amount;
-            // Clear data
             currentHead = node.nextTimestamp;
+            // Clear data
+            delete node.amount;
+            delete node.nextTimestamp;
             // forgefmt: disable-next-item
             unchecked {
                 ++iter;

--- a/assets/eip-7265/src/utils/LimiterLib.sol
+++ b/assets/eip-7265/src/utils/LimiterLib.sol
@@ -60,10 +60,10 @@ library LimiterLib {
             return;
         }
 
-        uint256 currentTickTimestamp = block.timestamp - (block.timestamp % tickLength);
+        uint32 currentTickTimestamp = uint32(block.timestamp - (block.timestamp % tickLength));
         limiter.liqInPeriod += amount;
 
-        uint256 listHead = limiter.listHead;
+        uint32 listHead = limiter.listHead;
         if (listHead == 0) {
             // if there is no head, set the head to the new inflow
             limiter.listHead = currentTickTimestamp;
@@ -81,7 +81,7 @@ library LimiterLib {
             }
 
             // check if tail is the same as block.timestamp (multiple txs in same block)
-            uint256 listTail = limiter.listTail;
+            uint32 listTail = limiter.listTail;
             if (listTail == currentTickTimestamp) {
                 // add amount
                 limiter.listNodes[currentTickTimestamp].amount += amount;
@@ -108,7 +108,7 @@ library LimiterLib {
         uint256 withdrawalPeriod,
         uint256 totalIters
     ) internal {
-        uint256 currentHead = limiter.listHead;
+        uint32 currentHead = limiter.listHead;
         int256 totalChange = 0;
         uint256 iter = 0;
 
@@ -129,8 +129,8 @@ library LimiterLib {
 
         if (currentHead == 0) {
             // If the list is empty, set the tail and head to current times
-            limiter.listHead = block.timestamp;
-            limiter.listTail = block.timestamp;
+            limiter.listHead = uint32(block.timestamp);
+            limiter.listTail = uint32(block.timestamp);
         } else {
             limiter.listHead = currentHead;
         }

--- a/assets/eip-7265/test/core/admin/CircuitBreakerAdminOps.t.sol
+++ b/assets/eip-7265/test/core/admin/CircuitBreakerAdminOps.t.sol
@@ -197,6 +197,7 @@ contract CircuitBreakerAdminOpsTest is Test {
         bool overrideStatus = true;
         bool expected = true;
 
+        vm.prank(admin);
         bool result = circuitBreaker.setLimiterOverriden(
             identifier,
             overrideStatus

--- a/assets/eip-7265/test/core/asset-circuit-breaker/AssetCircuitBreaker.t.sol
+++ b/assets/eip-7265/test/core/asset-circuit-breaker/AssetCircuitBreaker.t.sol
@@ -183,6 +183,7 @@ contract AssetCircuitBreakerTest is Test {
         bytes32 tokenIdentifier = circuitBreaker.getTokenIdentifier(
             address(token)
         );
+        vm.prank(admin);
         circuitBreaker.setLimiterOverriden(tokenIdentifier, true);
 
         uint256 withdrawalAmount = 300_001e18;

--- a/assets/eip-7265/test/core/user/CircuitBreakerUserOps.t.sol
+++ b/assets/eip-7265/test/core/user/CircuitBreakerUserOps.t.sol
@@ -363,7 +363,6 @@ contract CircuitBreakerUserOpsTest is Test {
 
         vm.warp(4 days);
         vm.prank(alice);
-        circuitBreaker.overrideExpiredRateLimit();
         assertEq(circuitBreaker.isRateLimited(), false);
     }
 


### PR DESCRIPTION
# CircuitBreaker Optimizations

Simplifies and optimizes the base CircuitBreaker contract. Main changes include:

- using solidity 0.8.22
- Get rid of `overrideExpiredRateLimit`, now the rate limit expires on it's own:
         `astRateLimitTimestamp` & `isRateLimited` removed in favor of `rateLimitEndTimestamp`
- Added onlyOwner to setLimiterOverriden to avoid anyone overriding limiter freely
- gas optimizations in LimiterLib (optimized as is, use of storage to avoid large structs in memory)
-  Using uint32 for timestamp (if max year 2106 is a problem, uint40 can be used)


Future possible (breaking) changes include:
- Unifying registering and updating into one, deals with event and syncing on it's own
- Storing amounts in an array per each period, instead of in a linked list per each timestamp. This would be a large optimization, but would slightly change the logic. Instead of having the period be a lookback of X time from the present, period would be measured as multiples of X from a starting time.
- Maybe reducing amount variables from 256 to pack with uint32 timestamps. Depends on if liquidity amounts will fit in int192 without overflowing
